### PR TITLE
Optional installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,30 @@ cd badger
 pip install -e .
 ```
 
+If you want to use Badger with SVGs hosted on the web, you will need to install `requests`. Change the last line to:
+
+```bash
+pip install -e ".[web]"
+```
+
+If you want to use the `badger go-wild` command, you will need to install `openai`. Change the last line to:
+
+```bash
+pip install -e ".[wild]"
+```
+
+And make sure to set your OpenAI API key as an environment variable:
+
+```bash
+export OPENAI_API_KEY=<YOUR_API_KEY>
+```
+
+To install both, change the last line to:
+
+```bash
+pip install -e ".[web,wild]"
+```
+
 ## 📝 Usage
 
 Here's how you can use Badger:

--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,12 @@ setup(
     version="0.1",
     packages=find_packages(),
     install_requires=[
-        # List your project dependencies here
         "pyperclip",
-        # 'requests',  # Uncomment if you're using the requests library
-        # 'openai',    # Uncomment if you're using the OpenAI API
     ],
+    extras_require={
+        "web": ["requests"],
+        "wild": ["openai"],
+    },
     entry_points={"console_scripts": ["badger = src.badger:main"]},
     author="Voxel51, Inc.",
     author_email="info@voxel51.com",


### PR DESCRIPTION
Changed `setup.py` to include optional installs:

If you want to use Badger with SVGs hosted on the web, you will need to install `requests`. Change the last line to:

```bash
pip install -e ".[web]"
```

If you want to use the `badger go-wild` command, you will need to install `openai`. Change the last line to:

```bash
pip install -e ".[wild]"
```

And make sure to set your OpenAI API key as an environment variable:

```bash
export OPENAI_API_KEY=<YOUR_API_KEY>
```

To install both, change the last line to:

```bash
pip install -e ".[web,wild]"
```