### PR TITLE
Contributor badges and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,22 @@ Commonly used colors:
 
 💡 As show in this example, you can create a badge from an SVG at a URL! If you do so, the content of the SVG will be retrieved at badge generation time using `requests`. You can also use local SVGs by specifying the relative or absolute path to the SVG file.
 
+#### 💡 Simple Mode
+
+You can also create a badge in simple mode by passing the `--simple` flag:
+
+```bash
+badger create --simple --badge_name simple_badge --logo assets/fiftyone.svg --url https://github.com/voxel51/fiftyone --text FiftyOne
+```
+
+This will bypass the optional prompts and create a badge with the specified parameters. The `--simple` flag can be used anywhere in the command, before or after the `create` command.
+
+If you find yourself wanting to use this mode often, you can create an alias for it:
+
+```bash
+alias badgers="badger create --simple"
+```
+
 ### 📋 Copy a Badge to Clipboard
 
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,9 @@ setup(
     name="badger",
     version="0.1",
     packages=find_packages(),
-    install_requires=[
-        "pyperclip",
-    ],
+    install_requires=["argparse", "pyperclip", "xml"],
     extras_require={
-        "web": ["requests"],
+        "web": ["bs4", "requests"],
         "wild": ["openai"],
     },
     entry_points={"console_scripts": ["badger = src.badger:main"]},

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     name="badger",
     version="0.1",
     packages=find_packages(),
-    install_requires=["argparse", "pyperclip", "xml"],
+    install_requires=["argparse", "pyperclip"],
     extras_require={
         "web": ["bs4", "requests"],
         "wild": ["openai"],

--- a/src/badger.py
+++ b/src/badger.py
@@ -208,7 +208,7 @@ def create_fiftyone_contributor_badge(args, config):
 
     badges = config.load_config()  # Load the current config
 
-    if args.badge_name in badges:
+    if args.badge_name:
         badge_name = args.badge_name
     else:
         req = get_required_string("badge_name")
@@ -230,6 +230,7 @@ def create_fiftyone_contributor_badge(args, config):
     new_badge_data = {}
     new_badge_data["label"] = "contributor"
     new_badge_data["labelColor"] = CONTRIBUTOR_LABEL_COLOR
+    new_badge_data["logo"] = "assets/fiftyone.svg"
 
     def _variant_to_color(variant):
         if not variant.isdigit():
@@ -262,7 +263,7 @@ def create_fiftyone_contributor_badge(args, config):
             value = input(f"Enter the GitHub username to link to: ")
             key, value = _handle_props(value, key)
         elif key == "name":
-            username = new_badge_data["username"]
+            username = new_badge_data["url"].split("=")[-1]
             if username:
                 value = extract_name_from_github(username)
                 if not value:
@@ -513,7 +514,7 @@ def main():
         "contribute", help="Create a new fiftyone contributor badge."
     )
     contributor_parser.add_argument(
-        "badge_name", nargs="?", default=None, help="Name of the new badge."
+        "--badge_name", help="Name of the new badge."
     )
     contributor_parser.add_argument(
         "--name", help="Name to be displayed on the badge."

--- a/src/badger.py
+++ b/src/badger.py
@@ -162,7 +162,7 @@ def create_badge(args, config):
 
     badges = config.load_config()  # Load the current config
 
-    if args.badge_name in badges:
+    if args.badge_name:
         badge_name = args.badge_name
     else:
         req = get_required_string("badge_name")
@@ -527,6 +527,9 @@ def main():
     )
     contributor_parser.add_argument("--style", help="Style override.")
     contributor_parser.add_argument("--logoWidth", help="Logo width override.")
+    contributor_parser.add_argument(
+        "--simple", action="store_true", help="Skip interactive inputs."
+    )
 
     ### GO WILD
     go_wild_parser = subparsers.add_parser(

--- a/src/utils.py
+++ b/src/utils.py
@@ -25,7 +25,7 @@ def list_badges(badges):
     for badge_name, args in badges.items():
         url = args.get("url", "N/A")
         color = args.get("color", "N/A")
-        text = args.get("text", "N/A")
+        text = args.get("text", "")
         print(
             "{:<20} {:<50} {:<20} {:<20}".format(badge_name, url, color, text)
         )
@@ -126,7 +126,7 @@ def generate_badge_markdown(badge_config):
 
     # Dynamic URL construction
     base_url = "https://img.shields.io/badge/"
-    badge_text = badge_config.get("text", "N/A").replace(" ", "%20").strip()
+    badge_text = badge_config.get("text", "").replace(" ", "%20").strip()
     color = badge_config.get("color", "blue")
 
     badge_url = f"{base_url}{badge_text}-{color}.svg?"
@@ -221,3 +221,16 @@ def extract_name_from_github(username):
             return None
     else:
         return None
+
+
+def create_unique_badge_name(badges):
+    base = "badge"
+    if base not in badges:
+        return base
+    else:
+        i = 1
+        while True:
+            name = f"{base}{i}"
+            if name not in badges:
+                return name
+            i += 1

--- a/src/utils.py
+++ b/src/utils.py
@@ -193,3 +193,31 @@ def save_as_badge(file_name, config):
     config.update_config(badges)
 
     print(f"New badge '{badge_name}' has been saved.")
+
+
+def extract_name_from_github(username):
+    import requests
+    from bs4 import BeautifulSoup
+
+    # Fetch the HTML content of the GitHub profile
+    url = f"https://github.com/{username}"
+    response = requests.get(url)
+
+    # Check if the request was successful
+    if response.status_code == 200:
+        # Parse the HTML content
+        soup = BeautifulSoup(response.text, "html.parser")
+
+        # Find the tag containing the user's name
+        name_tag = soup.find(
+            "span", {"class": "p-name vcard-fullname d-block overflow-hidden"}
+        )
+
+        if name_tag:
+            # Extract and print the name
+            name = name_tag.text.strip()
+            return name
+        else:
+            return None
+    else:
+        return None


### PR DESCRIPTION
- `badger contribute` command, which generates a FiftyOne contributor badge
- Utility `extract_name_from_github()` for getting the name from a user's GitHub profile
- `create_unique_badge_name()` for ensuring unique badge names in simple mode
- `--simple` arg for bypassing the interactive prompts for optional params
- Updates to README 